### PR TITLE
Fix bug in update that masked 2s from the tens digit for hours.

### DIFF
--- a/src/SparkFunDS1307RTC.cpp
+++ b/src/SparkFunDS1307RTC.cpp
@@ -162,8 +162,8 @@ bool DS1307::update(void)
 				_pm = true;
 			else
 				_pm = false;
+			_time[TIME_HOURS] &= 0x1F; // Mask out 24-hour bit from hours
 		}
-		_time[TIME_HOURS] &= 0x1F; // Mask out 24-hour bit from hours
 		
 		return true;
 	}


### PR DESCRIPTION
BrieucDM opened an issue for this bug.  I forked the repository and updated the cpp file with his fix, which works perfectly.
